### PR TITLE
Map will not loaded in Backend, if SSL activated. Check for component parameter "load_api_ssl" is missing.

### DIFF
--- a/views/phocamapsgmap/tmpl/default.php
+++ b/views/phocamapsgmap/tmpl/default.php
@@ -7,7 +7,7 @@ $map	= new PhocaMapsMap($id);
 if ($this->type == 'marker') {
 	$map->loadCoordinatesJS();
 }
-$map->loadAPI();
+$map->loadAPI('jsapi', $this->enable_ssl);
 
 echo '<div align="center" style="margin:0;padding:0">';
 echo '<div id="phocaMap'.$id.'" style="margin:0;padding:0;width:750px;height:480px"></div></div>';

--- a/views/phocamapsgmap/view.html.php
+++ b/views/phocamapsgmap/view.html.php
@@ -16,6 +16,7 @@ class PhocaMapsCpViewPhocaMapsGMap extends JViewLegacy
 	protected $zoom;
 	protected $type;
 	protected $t;
+	protected $enable_ssl;
 	
 	public function display($tpl = null) {
 
@@ -25,6 +26,7 @@ class PhocaMapsCpViewPhocaMapsGMap extends JViewLegacy
 		$this->longitude	= JRequest::getVar( 'lng', '-30', 'get', 'string' );
 		$this->zoom			= JRequest::getVar( 'zoom', '2', 'get', 'string' );
 		$this->type			= JRequest::getVar( 'type', 'map', 'get', 'string' );
+		$this->enable_ssl = JComponentHelper::getParams('com_phocamaps')->get('load_api_ssl');
 		
 		$document	= JFactory::getDocument();
 		$document->addCustomTag( "<style type=\"text/css\"> \n" 


### PR DESCRIPTION
If you activate SSL for backend and set in component options "Enable SSL API Load", API will no be loaded.

**Options:**
![image](https://cloud.githubusercontent.com/assets/4247900/13191362/7209594a-d763-11e5-8bf9-6b4932fb34d7.png)

**Set coordinates:**
![image](https://cloud.githubusercontent.com/assets/4247900/13191307/178d40a8-d763-11e5-98e0-e4b325e6c7d9.png)

**Error:**
![image](https://cloud.githubusercontent.com/assets/4247900/13191398/b2eb44f0-d763-11e5-9fcb-574c4affd497.png)

![image](https://cloud.githubusercontent.com/assets/4247900/13191505/8911d706-d764-11e5-96a1-dce2dc6a924a.png)

It is because you don't check in **/com_phocamaps_v3.0.1/views/phocamapsgmap/tmpl/default.php**
the component settings

**See image:**
![image](https://cloud.githubusercontent.com/assets/4247900/13191441/fecb92ee-d763-11e5-8b72-56a098344cd8.png)

Im my patch I added a check for the component parameter "load_api_ssl" and now it works.