### PR TITLE
add google maps lazy loading xy px before show map element and add ip…

### DIFF
--- a/admin/config.xml
+++ b/admin/config.xml
@@ -44,6 +44,8 @@
 </field>
 
 <field name="maps_api_key" default=""  type="text" label="COM_PHOCAMAPS_FIELD_MAPS_API_KEY_LABEL" description="COM_PHOCAMAPS_FIELD_MAPS_API_KEY_DESC"/>
+<field name="google_maps_lazy_loading" type="number" default="300" min="0" filter="integer" label="COM_PHOCAMAPS_FIELD_GOOGLEMAPS_LAZYLOADING_LABEL" description="COM_PHOCAMAPS_FIELD_GOOGLEMAPS_LAZYLOADING_DESC" />
+<field name="ip_list" type="iplist" default="" label="COM_PHOCAMAPS_FIELD_GOOGLEMAPS_IPLIST_LABEL" description="COM_PHOCAMAPS_FIELD_GOOGLEMAPS_IPLIST_DESC" rows="10" cols="35" />
 
 
 

--- a/admin/language/en-GB/en-GB.com_phocamaps.ini
+++ b/admin/language/en-GB/en-GB.com_phocamaps.ini
@@ -8,6 +8,13 @@
 ;
 ; @test utf-8 ä, ö, ü
 ;
+;[6.0.1]
+COM_PHOCAMAPS_FIELD_GOOGLEMAPS_LAZYLOADING_LABEL="Lazy loading [px]"
+COM_PHOCAMAPS_FIELD_GOOGLEMAPS_LAZYLOADING_DESC="Load the map when the distance to the map is less than… (in px)"
+COM_PHOCAMAPS_FIELD_GOOGLEMAPS_IPLIST_LABEL="IP list - Develop mode"
+COM_PHOCAMAPS_FIELD_GOOGLEMAPS_IPLIST_DESC="List of IP addresses that will have developer mode enabled only"
+COM_PHOCAMAPS_FIELD_IP_FILTER_ADD_CURRENT="Add curent"
+COM_PHOCAMAPS_FIELD_IP_FILTER_CLEAR="Clear"
 
 ;[5.0.0]
 COM_PHOCAMAPS_CURRENT_LOCATION="Current Location"

--- a/admin/models/fields/iplist.php
+++ b/admin/models/fields/iplist.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @package n3t Debug
+ * @author Pavel Poles - n3t.cz
+ * @copyright (C) 2016 - 2025 - Pavel Poles - n3t.cz
+ * @license GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+**/
+
+defined( '_JEXEC' ) or die;
+
+use Joomla\CMS\Form\Field\TextareaField;
+use Joomla\CMS\Form\FormHelper;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Version;
+use Joomla\Utilities\IpHelper;
+
+if (Version::MAJOR_VERSION == 3) {
+  FormHelper::loadFieldClass('textarea');
+  class_alias('JFormFieldTextarea', '\\Joomla\\CMS\\Form\\Field\\TextareaField');
+}
+
+class JFormFieldIPList extends TextareaField
+{
+	protected $type = 'IPList';
+
+	protected function getInput()
+	{
+    $button = '<br />';
+    $onclick = "var input = document.getElementById('jform_".$this->element['name']."'); input.value +=  (input.value ? '\\n' : '') + '" . IpHelper::getIp() . "'; return false;";
+    $button.= '<button class="btn btn-success" onclick="'.$onclick.'" href="#">' . Text::_('COM_PHOCAMAPS_FIELD_IP_FILTER_ADD_CURRENT') . '</button>';
+    $onclick = "document.getElementById('jform_".$this->element['name']."').value = ''; return false;";
+    $button.= ' <button class="btn btn-danger" onclick="' . $onclick . '">' . Text::_('COM_PHOCAMAPS_FIELD_IP_FILTER_CLEAR') . '</button>';
+    return parent::getInput().$button;
+	}
+}

--- a/phocamaps.xml
+++ b/phocamaps.xml
@@ -7,7 +7,7 @@
 	<authorUrl>https://www.phoca.cz</authorUrl>
 	<copyright>Jan Pavelka</copyright>
 	<license>GNU/GPL</license>
-	<version>6.0.0</version>
+	<version>6.0.1</version>
 	<description>COM_PHOCAMAPS_XML_DESCRIPTION</description>
 	<namespace path="src">Phoca\Component\Phocamaps</namespace>
 	<scriptfile>script.php</scriptfile>


### PR DESCRIPTION
Ahoj Honzo,
posílám úpravy
- přidán lazyloading google maps, mapa se načte daný počet px před elementem aby se zbytečně nenačítala při běžném načtení stránky když je mapa mimo viewport
- ip list pro "develop mode", pro dané IP adresy odebere API key a nechá jen mapu s náhledem For development purposes only, já to používám třeba pro firemní IP adresu ze které máme největší návštěvnost na webu a nemusí to zbytečně žrát kredit